### PR TITLE
unexpected exception SMTPConnectError

### DIFF
--- a/yagmail/sender.py
+++ b/yagmail/sender.py
@@ -141,7 +141,8 @@ class SMTPBase:
         headers=None,
     ):
         """ Use this to send an email with gmail"""
-        self.login()
+        if self.is_closed:
+            self.login()
         recipients, msg_string = self.prepare_send(
             to, subject, contents, attachments, cc, bcc, headers
         )


### PR DESCRIPTION
Send more than one email, will raise SMTPConnectError.
ErrorMessage: SMTPConnectError: (421, b'Too many connections').