### PR TITLE
Making oauth2 file more user friendly

### DIFF
--- a/yagmail/oauth2.py
+++ b/yagmail/oauth2.py
@@ -107,8 +107,8 @@ def get_oauth2_info(oauth2_file):
         print("If you do not have an app registered for your email sending purposes, visit:")
         print("https://console.developers.google.com")
         print("and create a new project.\n")
-        email_addr = getpass.getpass("Your 'email address': ")
-        google_client_id = getpass.getpass("Your 'google_client_id': ")
+        email_addr = input("Your 'email address': ")
+        google_client_id = input("Your 'google_client_id': ")
         google_client_secret = getpass.getpass("Your 'google_client_secret': ")
         google_refresh_token, _, _ = get_authorization(google_client_id, google_client_secret)
         oauth2_info = {


### PR DESCRIPTION
getpass.getpass() is replaced with input() for the email input and ID input. Secret input is still getpass.getpass() although it can easily be input() because all this info is stored unencrypted in a file on the system. Anyway I'll leave it like that so there is some secrecy to it.