### PR TITLE
Add support for attaching bytes objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Note that people who obtain the file can send emails, but nothing else. As soon 
 
 The `contents` argument will be smartly guessed. It can be passed a string (which will be turned into a list); or a list. For each object in the list:
 
-- If it is a dictionary it will assume the key is the content and the value is an alias (only for images currently!)
+- If it is a dictionary it will assume the key is the content, and the value is an alias (only for images currently!)
   e.g. {'/path/to/image.png' : 'MyPicture'}
 - It will try to see if the content (string) can be read as a file locally,
   e.g. '/path/to/image.png'
@@ -182,6 +182,34 @@ As of version 0.4.94, `raw` and `inline` have been added.
 
 - `raw` ensures a string will not receive any "magic" (inlining, html, attaching)
 - `inline` will make an image appear in the text.
+
+### Attaching Files
+There are multiple ways to attach files in the `attachments` parameter (in addition to magical `contents` parameter).
+1. One can pass a list of paths i.e.
+```python
+yag.send(to=recipients,
+         subject=email_subject,
+         contents=contents,
+         attachments=['path/to/attachment1.png', 'path/to/attachment2.pdf', 'path/to/attachment3.zip']
+)
+```
+2. One can pass an instance of [`io.IOBase`](https://docs.python.org/3/library/io.html#io.IOBase).
+```python
+with open('path/to/attachment', 'rb') as f:
+    yag.send(to=recipients,
+             subject=email_subject,
+             contents=contents,
+             attachments=f
+             )
+```
+In this example `f` is an instance of `_io.BufferedReader` a subclass of the abstract class `io.IOBase`.
+
+`f` has in this example the attribute `.name`, which is used by yagmail as filename as well as to detect the correct MIME-type.
+Not all `io.IOBase` instances have the `.name` attribute in which case yagmail names the attachments `attachment1`, `attachment2`, ... without a file extension!
+Therefore, it is highly recommended setting the filename with extension manually e.g. `f.name = 'my_document.pdf'`
+
+A real-world example would be if the attachment is retrieved from a different source than the disk (e.g. downloaded from the internet or [uploaded by a user in a web-application](https://docs.streamlit.io/en/stable/api.html#streamlit.file_uploader)) 
+
 
 ### Feedback
 

--- a/yagmail/message.py
+++ b/yagmail/message.py
@@ -63,7 +63,7 @@ def prepare_message(
     if attachments is not None:
         for a in attachments:
             if not isinstance(a, io.IOBase) and not os.path.isfile(a):
-                raise TypeError(f'{a} must be a valid filepath or instance of io.IOBase. {a} is of type {type(a)}')
+                raise TypeError(f'{a} must be a valid filepath or file handle (instance of io.IOBase). {a} is of type {type(a)}')
         contents = attachments if contents is None else contents + attachments
 
     if contents is not None:


### PR DESCRIPTION
There are two ways to attach bytes objects:
1. Directly: I.e. `attachments` becomes a list of bytes objects
2. Via a tuple (str, bytes), where the first element is the filename and the second element the file contents.

1. was the first implementation, but I noticed that the filename + suffix was garbled and therefore not user friendly.
Not sure that option should even be supported.

For passing a tuple in 2. it was required to modify the `serialize_object` function to ignore tuples.
Not sure, whether is a backwards incompatible change? Otherwise maybe create a dummy class, like `raw` or `inline`.