### PR TITLE
Add non-inline images as attachments

### DIFF
--- a/yagmail/message.py
+++ b/yagmail/message.py
@@ -123,6 +123,8 @@ def prepare_message(
                     msg_related.attach(content_object["mime_object"])
                 else:
                     # non-inline images get attached like any other attachment
+                    content_object["mime_object"].add_header("Content-Disposition",
+                                                            f"attachment; filename= {content_string}")
                     msg.attach(content_object["mime_object"])
 
             else:


### PR DESCRIPTION
This PR addresses issue #224 by adding an attachment headers to images in the `attachments` list. Images will still display inline if `yagmail.inline()` is used. 

I tested this in the master branch and everything worked as expected, but let me know if this causes any other problems for you. Sample header:
```
--===============6820474337442594020==
Content-Type: image/jpeg; name*=utf-8''image.jpg
MIME-Version: 1.0
Content-Transfer-Encoding: base64
Content-Disposition: attachment; filename= image.jpg
```

Thank you for all your work!