### PR TITLE
Oauth2: Only ask for mail address if not provided

### DIFF
--- a/yagmail/oauth2.py
+++ b/yagmail/oauth2.py
@@ -98,7 +98,7 @@ def get_oauth_string(user, oauth2_info):
     return auth_string
 
 
-def get_oauth2_info(oauth2_file):
+def get_oauth2_info(oauth2_file: str, email_addr: str):
     oauth2_file = os.path.expanduser(oauth2_file)
     if os.path.isfile(oauth2_file):
         with open(oauth2_file) as f:
@@ -107,7 +107,8 @@ def get_oauth2_info(oauth2_file):
             oauth2_info = oauth2_info["installed"]
         except KeyError:
             return oauth2_info
-        email_addr = input("Your 'email address': ")
+        if email_addr is None:
+            email_addr = input("Your 'email address': ")
         google_client_id = oauth2_info["client_id"]
         google_client_secret = oauth2_info["client_secret"]
         google_refresh_token, _, _ = get_authorization(google_client_id, google_client_secret)
@@ -123,7 +124,8 @@ def get_oauth2_info(oauth2_file):
         print("If you do not have an app registered for your email sending purposes, visit:")
         print("https://console.developers.google.com")
         print("and create a new project.\n")
-        email_addr = input("Your 'email address': ")
+        if email_addr is None:
+            email_addr = input("Your 'email address': ")
         google_client_id = input("Your 'google_client_id': ")
         google_client_secret = getpass.getpass("Your 'google_client_secret': ")
         google_refresh_token, _, _ = get_authorization(google_client_id, google_client_secret)

--- a/yagmail/sender.py
+++ b/yagmail/sender.py
@@ -39,7 +39,7 @@ class SMTP:
         self.set_logging()
         self.soft_email_validation = soft_email_validation
         if oauth2_file is not None:
-            oauth2_info = get_oauth2_info(oauth2_file)
+            oauth2_info = get_oauth2_info(oauth2_file, user)
             if user is None:
                 user = oauth2_info["email_address"]
         if smtp_skip_login and user is None:


### PR DESCRIPTION
Even affects the example code in the readme, where own email is provided in code but still needs to be entered when run