### PR TITLE
Fix OAuth authorization expiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ After you provide them, a link will be shown in the terminal that you should fol
 
 Note that people who obtain the file can send emails, but nothing else. As soon as you notice, you can simply disable the token.
 
+#### Preventing OAuth authorization from expiring after 7 days
+
+Your Google Cloud Platform project's OAuth consent screen must be in **"In production" publishing status** before authorizing to not have the authorization expire after 7 days. See status at https://console.cloud.google.com/apis/credentials/consent
+
+Your OAuth **client ID must be of type "Desktop"**. Check at https://console.cloud.google.com/apis/credentials
+
 ### Magical `contents`
 
 The `contents` argument will be smartly guessed. It can be passed a string (which will be turned into a list); or a list. For each object in the list:

--- a/yagmail/oauth2.py
+++ b/yagmail/oauth2.py
@@ -101,6 +101,8 @@ def get_oauth_string(user, oauth2_info):
 
 
 def get_oauth2_info(oauth2_file):
+    oauth_setup_readme_link = "See readme for proper setup, preventing authorization from expiring after 7 days!"
+
     oauth2_file = os.path.expanduser(oauth2_file)
     if os.path.isfile(oauth2_file):
         with open(oauth2_file) as f:
@@ -109,6 +111,7 @@ def get_oauth2_info(oauth2_file):
             oauth2_info = oauth2_info["installed"]
         except KeyError:
             return oauth2_info
+        print(oauth_setup_readme_link)
         email_addr = input("Your 'email address': ")
         google_client_id = oauth2_info["client_id"]
         google_client_secret = oauth2_info["client_secret"]
@@ -125,6 +128,7 @@ def get_oauth2_info(oauth2_file):
         print("If you do not have an app registered for your email sending purposes, visit:")
         print("https://console.developers.google.com")
         print("and create a new project.\n")
+        print(oauth_setup_readme_link)
         email_addr = input("Your 'email address': ")
         google_client_id = input("Your 'google_client_id': ")
         google_client_secret = getpass.getpass("Your 'google_client_secret': ")

--- a/yagmail/oauth2.py
+++ b/yagmail/oauth2.py
@@ -101,7 +101,7 @@ def get_oauth_string(user, oauth2_info):
 
 
 def get_oauth2_info(oauth2_file: str, email_addr: str):
-    oauth_setup_readme_link = "See readme for proper setup, preventing authorization from expiring after 7 days!"
+    oauth_setup_readme_link = "See readme for proper setup, preventing authorization from expiring after 7 days! https://github.com/kootenpv/yagmail/blob/master/README.md#preventing-oauth-authorization-from-expiring-after-7-days"
     oauth2_file = os.path.expanduser(oauth2_file)
     if os.path.isfile(oauth2_file):
         with open(oauth2_file) as f:

--- a/yagmail/oauth2.py
+++ b/yagmail/oauth2.py
@@ -12,10 +12,11 @@ import json
 import getpass
 
 try:
-    from urllib.parse import urlencode, quote, unquote
+    from urllib.parse import urlencode, quote, unquote, parse_qs, urlsplit
     from urllib.request import urlopen
 except ImportError:
     from urllib import urlencode, quote, unquote, urlopen
+    from urlparse import parse_qs, urlsplit
 
 try:
     input = raw_input
@@ -23,7 +24,7 @@ except NameError:
     pass
 
 GOOGLE_ACCOUNTS_BASE_URL = 'https://accounts.google.com'
-REDIRECT_URI = 'urn:ietf:wg:oauth:2.0:oob'
+REDIRECT_URI = 'http://localhost'
 
 
 def command_to_url(command):
@@ -82,7 +83,8 @@ def generate_oauth2_string(username, access_token, as_base64=False):
 def get_authorization(google_client_id, google_client_secret):
     permission_url = generate_permission_url(google_client_id)
     print('Navigate to the following URL to auth:\n' + permission_url)
-    authorization_code = input('Enter verification code: ')
+    url = input('Enter the localhost URL you were redirected to: ')
+    authorization_code = parse_qs(urlsplit(url).query)['code'][0]
     response = call_authorize_tokens(google_client_id, google_client_secret, authorization_code)
     return response['refresh_token'], response['access_token'], response['expires_in']
 


### PR DESCRIPTION
Google OAuth authorizations expire after 7 days if issued while the project was in "Testing" mode. [1]

Maybe *the authorization itself* expires, i.e. every token associated with it. So you can't just fix it by refreshing earlier (using the refresh token earlier to get a new auth token). [2] It would anyway be a more complicated setup since refreshing would need to be scheduled.

=> (Google Cloud Console) projects shall use "In Production" status
If your project is in status “in production”, the refresh token will last longer (indefinitely, as I understand). [3]

---

Yagmail currently uses OOB auth which will not be supported in projects with "In Production" status.
=> Switch to a localhost redirect_uri. (which is *still allowed for Desktop type clients*)
[4]

---

Fixes #244, fixes #247

---

[1] https://stackoverflow.com/a/68776672
[2] https://stackoverflow.com/a/67966982
[3] https://stackoverflow.com/questions/8953983/do-google-refresh-tokens-expire
[4] https://developers.google.com/identity/protocols/oauth2/resources/oob-migration#desktop-client