### PR TITLE
fix: typo on root README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ As a side note, `yagmail` can now also be used to send emails from the command l
 ### Start a connection
 
 ```python
-yag = yagmail.SMTP('mygmailusername', 'mygmailpassword)
+yag = yagmail.SMTP('mygmailusername', 'mygmailpassword')
 ```
 
 Note that this connection is reusable, closable and when it leaves scope it will **clean up after itself in CPython**.


### PR DESCRIPTION
### Start a connection
Example on L#59 of the root README.md file was missing a closing `'`