### PR TITLE
Update attachment headers

### DIFF
--- a/yagmail/message.py
+++ b/yagmail/message.py
@@ -230,9 +230,8 @@ def get_mime_object(is_marked_up, content_string, encoding):
             content_object["main_type"] = "application"
             content_object["sub_type"] = "octet-stream"
 
-    mime_object = MIMEBase(content_object["main_type"], content_object["sub_type"], name=(encoding, "", content_name))
+    mime_object = MIMEBase(content_object["main_type"], content_object["sub_type"], name=content_name)
     mime_object.set_payload(content)
-    if content_object["main_type"] == "application":
-        mime_object.add_header("Content-Disposition", "attachment", filename=content_name)
+    mime_object.add_header("Content-Disposition", "attachment", filename=content_name, name=content_name)
     content_object["mime_object"] = mime_object
     return content_object


### PR DESCRIPTION
Refactor attachment MIME object to match other (working) providers per ProtonMail support
Closes #228 

I validated this change by sending an email to my gmail address (daniel@neongecko.com) and to a newly-created ProtonMail account. Both emails contained attachments as ecpected. A sample new header is included below.

```
Content-Type: text/plain; name="skills_log.txt"
MIME-Version: 1.0
Content-Disposition: attachment; filename="skills_log.txt"; name="skills_log.txt"
Content-Transfer-Encoding: base64
```